### PR TITLE
Fixes for modern Nim and add short example

### DIFF
--- a/examples/find_font.nim
+++ b/examples/find_font.nim
@@ -1,0 +1,32 @@
+#[
+Ported from:
+https://gist.github.com/CallumDev/7c66b3f9cf7a876ef75f
+]#
+
+import fontconfig
+proc findFont(s: string): string =
+  echo FcInit()
+  let cfg = FcInitLoadConfigAndFonts()
+  # make pattern from font name
+  let name = cast[ptr TFcChar8](cstring(s))
+  let pat = FcNameParse(name)
+  echo FcConfigSubstitute(cfg, pat, FcMatchPattern)
+  FcDefaultSubstitute(pat)
+  var fontFile: cstring # this is what we'd return if this was a function
+  # find the font
+  var res: TFcResult
+  var font: ptr TFcPattern = FcFontMatch(cfg, pat, res.addr)
+  echo res
+  if not font.isNil:
+    var f: ptr TFcChar8 = nil
+    if FcPatternGetString(font, FC_FILE, 0, f.addr) == FcResultMatch:
+      # we found the font, now print it.
+      # This might be a fallback font
+      result = $(cast[cstring](f))
+      echo result
+  FcPatternDestroy(font)
+  FcPatternDestroy(pat)
+  FcConfigDestroy(cfg)
+  FcFini()
+
+echo findFont("noto sans")

--- a/fontconfig.nim
+++ b/fontconfig.nim
@@ -525,7 +525,7 @@ proc FcCharSetIsSubset*(a: ptr TFcCharSet; b: ptr TFcCharSet): TFcBool {.cdecl,
     importc: "FcCharSetIsSubset", libfontconfig.}
 const
   FC_CHARSET_MAP_SIZE* = (256 div 32)
-  FC_CHARSET_DONE* = TFcChar32(-1)
+  FC_CHARSET_DONE* = TFcChar32(cuint.high)
 
 #FcPublic
 
@@ -1047,13 +1047,13 @@ proc FcStrFree*(s: ptr TFcChar8) {.cdecl, importc: "FcStrFree",
                                    libfontconfig.}
 # These are ASCII only, suitable only for pattern element names
 
-template FcIsUpper*(c: expr): expr =
+template FcIsUpper*(c: untyped): untyped =
   ((0o000000000101 <= (c) and (c) <= 0o000000000132))
 
-template FcIsLower*(c: expr): expr =
+template FcIsLower*(c: untyped): untyped =
   ((0o000000000141 <= (c) and (c) <= 0o000000000172))
 
-template FcToLower*(c: expr): expr =
+template FcToLower*(c: untyped): untyped =
   (if FcIsUpper(c): (c) - 0o000000000101 + 0o000000000141 else: (c))
 
 #FcPublic


### PR DESCRIPTION
Hey!

Not sure if you're still willing to maintain this library. Here are a few fixes to make the library usable on current Nim. I didn't update the bindings themselves (I suppose something may have changed in the years since, but for what I need it for, it seems to work).

I also added an example of how to use the library to find a font matching some string.